### PR TITLE
Opgops 1646 refresh

### DIFF
--- a/roles/awsenv/tasks/destroy_vpc.yml
+++ b/roles/awsenv/tasks/destroy_vpc.yml
@@ -66,6 +66,7 @@
     - name: Destroy route53 zone records
       shell: aws route53 change-resource-record-sets --hosted-zone-id "{{ internal_zone_id }}" --change-batch "file://{{ playbook_dir }}/route53-delete.json"
       changed_when: false
+      when: dns_zone_records.ResourceRecordSets.ResourceRecords|default([]) |count > 4
       tags:
         - skip_ansible_lint
 

--- a/roles/awsenv/tasks/destroy_vpc.yml
+++ b/roles/awsenv/tasks/destroy_vpc.yml
@@ -66,7 +66,7 @@
     - name: Destroy route53 zone records
       shell: aws route53 change-resource-record-sets --hosted-zone-id "{{ internal_zone_id }}" --change-batch "file://{{ playbook_dir }}/route53-delete.json"
       changed_when: false
-      when: dns_zone_records.ResourceRecordSets.ResourceRecords|default([]) |count > 4
+      when: dns_zone_records.ResourceRecordSets|default([]) |count > 2
       tags:
         - skip_ansible_lint
 

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -7,7 +7,7 @@
 #  create asg for app component
 - block:
     - block:
-        - name: get search string
+        - name: Setup facts for tasks
           set_fact:
             has_data_storage: "{{ asg_data.has_data_storage|default('no') }}"
 
@@ -90,13 +90,16 @@
       when: has_elb
 
     - set_fact:
-        lc_count: "{{ lc_facts.results|selectattr('launch_configuration_name','match', [asg_name,target,lc_pf.stdout]|join('-'))|list|count}}"
-        current_lc_name: {{ lc_facts.results||selectattrib('launch_configuration_name')|map('launch_configuration_name')|list }}
+        lc_name: "{{ [asg_name,target,lc_pf.stdout]|join('-') }}"
+
+    - set_fact:
+        lc_count: "{{ lc_facts.results|selectattr('launch_configuration_name','match', lc_name)|list|count}}"
+        existing_lc_name: {{ lc_facts.results||selectattrib('launch_configuration_name')|map('launch_configuration_name')|list }}
 
     - name: Remove old launch config
       ec2_lc:
         state: absent
-        name: "{{ current_lc_name[0] }}"
+        name: "{{ existing_lc_name[0] }}"
       when: lc_count == 0
 
     - name: Create autoscaling group without ELB

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -80,7 +80,7 @@
         health_check_type: 'ELB'
 #        replace_all_instances: yes
         wait_for_instances: True
-        wait_timeout: "{{ instance_wait_timeout|d(300) }}"
+        wait_timeout: "{{ instance_wait_timeout|d(600) }}"
         min_size: "{{ asg_data.min | default(2) }}"
         max_size: "{{ asg_data.max | default(2) }}"
         desired_capacity: "{{ asg_data.desired | default(2) }}"

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -80,6 +80,7 @@
         health_check_type: 'ELB'
 #        replace_all_instances: yes
         wait_for_instances: True
+        wait_timeout: "{{ instance_wait_timeout|d(300)}}
         min_size: "{{ asg_data.min | default(2) }}"
         max_size: "{{ asg_data.max | default(2) }}"
         desired_capacity: "{{ asg_data.desired | default(2) }}"

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -80,7 +80,7 @@
         health_check_type: 'ELB'
 #        replace_all_instances: yes
         wait_for_instances: True
-        wait_timeout: "{{ instance_wait_timeout|d(300)}}
+        wait_timeout: "{{ instance_wait_timeout|d(300) }}"
         min_size: "{{ asg_data.min | default(2) }}"
         max_size: "{{ asg_data.max | default(2) }}"
         desired_capacity: "{{ asg_data.desired | default(2) }}"

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -53,6 +53,12 @@
       register: lc_pf
       changed_when: False
 
+    - name: Get current launch config for ASG
+      ec2_asg_facts:
+        name: "{{ asg_name }}-{{ opg_data.stack }}"
+#        tags: "{{ vpc.env_tags | combine({ 'Name': asg_name + '-' + opg_data.stack, 'Role': asg_name})|dict_to_list }}"
+      register: lc_facts
+
     - name: Create launch configuration for app
       ec2_lc:
         state: present
@@ -72,8 +78,8 @@
         name: "{{ asg_name }}-{{ opg_data.stack }}"
         launch_config_name: "{{ asg_name }}-{{ opg_data.stack }}-{{ lc_pf.stdout }}"
         health_check_period: 900
-        health_check_type: 'EC2'
-#        replace_all_instances: yes
+        health_check_type: 'ELB'
+        replace_all_instances: yes
         wait_for_instances: False
         min_size: "{{ asg_data.min | default(2) }}"
         max_size: "{{ asg_data.max | default(2) }}"
@@ -83,6 +89,24 @@
         tags: "{{ vpc.env_tags | combine({ 'Name': asg_name + '-' + opg_data.stack, 'Role': asg_name})|dict_to_list }}"
         vpc_zone_identifier: "{{ asg_data.subnets }}"
       when: has_elb
+
+    - set_fact:
+        lc_count: "{{ lc_facts.results|selectattr('launch_configuration_name','match', [asg_name,target,lc_pf.stdout]|join('-'))|list|count}}"
+        current_lc_name: {{ lc_facts.results||selectattrib('launch_configuration_name')|map('launch_configuration_name')|list }}
+#    - debug:
+#        msg: "{{ lc_pf }}"
+#    - debug:
+#        msg: "{{ lc_facts }}"
+#    - debug:
+#            msg: "{{ lc_count }}"
+
+#    - pause: minutes=5
+    - name: Remove old launch config
+      ec2_lc:
+        state: absent
+        name: "{{ current_lc_name[0] }}"
+      when: lc_count == 0
+#    - pause: minutes=5
 
     - name: Create autoscaling group without ELB
       ec2_asg:

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -56,7 +56,6 @@
     - name: Get current launch config for ASG
       ec2_asg_facts:
         name: "{{ asg_name }}-{{ opg_data.stack }}"
-#        tags: "{{ vpc.env_tags | combine({ 'Name': asg_name + '-' + opg_data.stack, 'Role': asg_name})|dict_to_list }}"
       register: lc_facts
 
     - name: Create launch configuration for app
@@ -93,20 +92,12 @@
     - set_fact:
         lc_count: "{{ lc_facts.results|selectattr('launch_configuration_name','match', [asg_name,target,lc_pf.stdout]|join('-'))|list|count}}"
         current_lc_name: {{ lc_facts.results||selectattrib('launch_configuration_name')|map('launch_configuration_name')|list }}
-#    - debug:
-#        msg: "{{ lc_pf }}"
-#    - debug:
-#        msg: "{{ lc_facts }}"
-#    - debug:
-#            msg: "{{ lc_count }}"
 
-#    - pause: minutes=5
     - name: Remove old launch config
       ec2_lc:
         state: absent
         name: "{{ current_lc_name[0] }}"
       when: lc_count == 0
-#    - pause: minutes=5
 
     - name: Create autoscaling group without ELB
       ec2_asg:

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -94,7 +94,7 @@
 
     - set_fact:
         lc_count: "{{ lc_facts.results|selectattr('launch_configuration_name','match', lc_name)|list|count}}"
-        existing_lc_name: {{ lc_facts.results||selectattrib('launch_configuration_name')|map('launch_configuration_name')|list }}
+        existing_lc_name: "{{ lc_facts.results||selectattrib('launch_configuration_name')|map('launch_configuration_name')|list }}"
 
     - name: Remove old launch config
       ec2_lc:

--- a/roles/ec2-app/tasks/app-asg.yml
+++ b/roles/ec2-app/tasks/app-asg.yml
@@ -78,8 +78,8 @@
         launch_config_name: "{{ asg_name }}-{{ opg_data.stack }}-{{ lc_pf.stdout }}"
         health_check_period: 900
         health_check_type: 'ELB'
-        replace_all_instances: yes
-        wait_for_instances: False
+#        replace_all_instances: yes
+        wait_for_instances: True
         min_size: "{{ asg_data.min | default(2) }}"
         max_size: "{{ asg_data.max | default(2) }}"
         desired_capacity: "{{ asg_data.desired | default(2) }}"
@@ -94,7 +94,7 @@
 
     - set_fact:
         lc_count: "{{ lc_facts.results|selectattr('launch_configuration_name','match', lc_name)|list|count}}"
-        existing_lc_name: "{{ lc_facts.results||selectattrib('launch_configuration_name')|map('launch_configuration_name')|list }}"
+        existing_lc_name: "{{ lc_facts.results|selectattr('launch_configuration_name')|map(attribute='launch_configuration_name')|list }}"
 
     - name: Remove old launch config
       ec2_lc:
@@ -110,6 +110,7 @@
         health_check_period: 900
         health_check_type: 'EC2'
 #        replace_all_instances: yes
+        wait_for_instances: True
         min_size: "{{ asg_data.min | default(2) }}"
         max_size: "{{ asg_data.max | default(2) }}"
         desired_capacity: "{{ asg_data.desired | default(2) }}"

--- a/roles/ec2-app/tasks/destroy_stack.yml
+++ b/roles/ec2-app/tasks/destroy_stack.yml
@@ -172,10 +172,9 @@
         dest: "{{ playbook_dir }}/route53-delete.json"
       when: not 'vpc' in target
 
-
     - name: Destroy route53 private zone records
       shell: aws route53 change-resource-record-sets --hosted-zone-id "{{ internal_zone_id }}" --change-batch "file://{{ playbook_dir }}/route53-delete.json"
-      when: not 'vpc' in target and (dns_zone_records.ResourceRecordSets.ResourceRecords|default([]) |count > 4)
+      when: not 'vpc' in target and (dns_zone_records.ResourceRecordSets|default([]) |count > 2)
 
     - name: Destroy route53 private zone
       route53_zone:

--- a/roles/ec2-app/tasks/destroy_stack.yml
+++ b/roles/ec2-app/tasks/destroy_stack.yml
@@ -170,14 +170,18 @@
       template:
         src: 'route53-delete.json'
         dest: "{{ playbook_dir }}/route53-delete.json"
+      when: not 'vpc' in target
 
-    - name: Destroy route53 zone records
+
+    - name: Destroy route53 private zone records
       shell: aws route53 change-resource-record-sets --hosted-zone-id "{{ internal_zone_id }}" --change-batch "file://{{ playbook_dir }}/route53-delete.json"
+      when: not 'vpc' in target and (dns_zone_records.ResourceRecordSets.ResourceRecords|default([]) |count > 4)
 
-    - name: Destroy route53 entries and private zone
+    - name: Destroy route53 private zone
       route53_zone:
         zone: "{{ target }}.internal"
         state: absent
+      when: not 'vpc' in target
 
   when: not dns_zone_records|skipped and not dns_zone_records|failed
 


### PR DESCRIPTION
Introduces changes so that scaling groups with elbs will wait until each node his working on the elb rather than using ec2 status

this lays the foundation for the rolling updates.

current create node -> highstate finished is about 6 minutes based on lpa.