### PR TITLE
OPGOPS-1605 Remove VPC awsenv iam roles and policies.

### DIFF
--- a/roles/awsenv/tasks/destroy_vpc.yml
+++ b/roles/awsenv/tasks/destroy_vpc.yml
@@ -10,6 +10,21 @@
   set_fact:
     asg_list: "{{ instance_data.instances |rejectattr('tags.aws:autoscaling:groupName', 'undefined')| list | map(attribute='tags.aws:autoscaling:groupName') | list | unique }}"
 
+- name: Destroy awsenv common iam policy
+  iam_policy:
+    state: absent
+    policy_name: 'common-policy-{{ opg_data.stack }}'
+    iam_type: role
+    iam_name: '{{ item }}-role-{{ opg_data.stack }}'
+  with_items: "{{ vpc.iam_roles }}"
+
+- name: Destroy awsenv iam role
+  iam:
+    iam_type: role
+    name: '{{ item }}-role-{{ opg_data.stack }}'
+    state: absent
+  with_items: "{{ vpc.iam_roles }}"
+
 - name: Remove autoscaling groups
   ec2_asg:
     name: "{{ item }}"


### PR DESCRIPTION
Added some additional code to remove leftover iam roles.

There is a refactor to be done as the creation and destruction of these roles is done across different modules