### PR TITLE
Defaulted query string and squelched output when creating var

### DIFF
--- a/roles/sql-command/tasks/main.yml
+++ b/roles/sql-command/tasks/main.yml
@@ -63,6 +63,7 @@
       set_fact:
         sql_result: "{{ psql_result.stdout }}"
       when: psql_result.stdout is defined
+      no_log: True
   when: "'postgres' in rds_instance_data.db_engine | lower"
 
 - block:
@@ -73,12 +74,13 @@
       set_fact:
         sql_result: "{{ mysql_result.stdout }}"
       when: mysql_result.stdout is defined
+      no_log: True
   when: "'mysql' in rds_instance_data.db_engine | lower"
 
 - block:
     - name: Write our query to a file
       copy:
-        content: "Query: '{{ query_string }}'\n\n#SQL_OUTPUT#\n\n"
+        content: "Query: '{{ query_string|default('') }}'\n\n#SQL_OUTPUT#\n\n"
         dest: "{{ base_path }}{{ target }}_{{ date_stamp.stdout }}_sql_results.txt"
       connection: local
 


### PR DESCRIPTION
If the query_string var was unset, which is the case when a remote_sql file is used, the task failed hard, now if no query string is set, it defaults to a blank string, so only the output is logged