### PR TITLE
Repair wordpress sync job

### DIFF
--- a/roles/wordpress-sync/README.md
+++ b/roles/wordpress-sync/README.md
@@ -12,4 +12,9 @@ Role to syncronise wordpress data from one instance to another
  - restart_docker - Optional, do we want to restart the docker-compose service
  - domain_to_replace - Optional, what domain are we replacing when we do the SQL dump
  - domain_prefix - Optional, an override for the domain default is `wordpress.<domain>`
- 
+
+
+
+ansible-playbook -i hosts opg-playbooks/syncronise_wordpress.yml -e "target=dev-vpc" -e "sync_action=down"
+
+ansible-playbook -i hosts opg-playbooks/syncronise_wordpress.yml -e "target=dev-vpc" -e "sync_action=up" -e "restore_db=true"

--- a/roles/wordpress-sync/tasks/backup_db.yml
+++ b/roles/wordpress-sync/tasks/backup_db.yml
@@ -69,7 +69,7 @@
   delegate_to: localhost
 
 - name: Commit our changeset if there is one
-  shell: "git commit -m 'Update wordpress.sql dir {{ date_stamp }}'"
+  shell: "git commit -m 'Update wordpress.sql directory'"
   args:
     chdir: "{{ playbook_dir }}/uploads-content"
   delegate_to: localhost
@@ -79,4 +79,3 @@
   args:
     chdir: "{{ playbook_dir }}/uploads-content"
   delegate_to: localhost
-

--- a/roles/wordpress-sync/tasks/main.yml
+++ b/roles/wordpress-sync/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
 
+- name: "Load our wordpress vars into memory from {{ inventory_dir }}/group_vars/wordpress.yml"
+  include_vars:
+    file: "{{ inventory_dir }}/group_vars/wordpress.yml"
+
 - name: Get all wordpress hosts into an in memory group
   set_fact:
     wordpress_hosts: "{{ groups[vpc_name + '_wordpress'] }}"
+
 
 - name: Get latest wp-contents/uploads data
   git:

--- a/roles/wordpress-sync/tasks/pack.yml
+++ b/roles/wordpress-sync/tasks/pack.yml
@@ -44,7 +44,7 @@
       delegate_to: localhost
 
     - name: Commit our changeset if there is one
-      shell: "git commit -m 'Update uploads dir {{ date_stamp }}'"
+      shell: "git commit -m 'Update uploads directory'"
       args:
         chdir: "{{ playbook_dir }}/uploads-content"
       delegate_to: localhost
@@ -55,4 +55,4 @@
         chdir: "{{ playbook_dir }}/uploads-content"
       delegate_to: localhost
 
-  when: "{{ 'nothing to commit, working directory clean' not in git_status.stdout }}"
+  when: '"nothing to commit, working tree clean" not in git_status.stdout'


### PR DESCRIPTION
The wordpress sync job couldn't complete for a few reasons.

This adds 
the reference to wordpress.yml file to call to database facts
a fix for commit messages
a fix for clean commits.